### PR TITLE
Windowsでも動くように修正

### DIFF
--- a/builelib/airconditioning.py
+++ b/builelib/airconditioning.py
@@ -7,9 +7,9 @@ import copy
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
-import climate
-import shading
+from . import commons as bc
+from . import climate
+from . import shading
 
 # データベースファイルの保存場所
 database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
@@ -90,11 +90,11 @@ def calc_energy(inputdata, DEBUG = False):
     ##----------------------------------------------------------------------------------
 
     # 流量制御
-    with open(database_directory + 'FLOWCONTROL.json', 'r') as f:
+    with open(database_directory + 'FLOWCONTROL.json', 'r', encoding='utf-8') as f:
         FLOWCONTROL = json.load(f)
 
     # 熱源機器特性
-    with open(database_directory + "HeatSourcePerformance.json", 'r') as f:
+    with open(database_directory + "HeatSourcePerformance.json", 'r', encoding='utf-8') as f:
         HeatSourcePerformance = json.load(f)
 
     ##----------------------------------------------------------------------------------
@@ -121,7 +121,7 @@ def calc_energy(inputdata, DEBUG = False):
     ##----------------------------------------------------------------------------------
 
     # 地域別データの読み込み
-    with open(database_directory + 'AREA.json', 'r') as f:
+    with open(database_directory + 'AREA.json', 'r', encoding='utf-8') as f:
         Area = json.load(f)
 
     # 負荷率帯マトリックス mxL = array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2])
@@ -206,7 +206,7 @@ def calc_energy(inputdata, DEBUG = False):
     ##----------------------------------------------------------------------------------
 
     # 空調運転モード
-    with open(database_directory + 'ACoperationMode.json', 'r') as f:
+    with open(database_directory + 'ACoperationMode.json', 'r', encoding='utf-8') as f:
         ACoperationMode = json.load(f)
 
     # 各日の冷暖房期間の種類（冷房期、暖房期、中間期）（365×1の行列）
@@ -400,11 +400,11 @@ def calc_energy(inputdata, DEBUG = False):
     ### ISSUE : 二つのデータベースにわかれてしまっているので統一する。###
 
     # 標準入力法建材データの読み込み
-    with open(database_directory + 'HeatThermalConductivity.json', 'r') as f:
+    with open(database_directory + 'HeatThermalConductivity.json', 'r', encoding='utf-8') as f:
         HeatThermalConductivity = json.load(f)
 
     # モデル建物法建材データの読み込み
-    with open(database_directory + 'HeatThermalConductivity_model.json', 'r') as f:
+    with open(database_directory + 'HeatThermalConductivity_model.json', 'r', encoding='utf-8') as f:
         HeatThermalConductivity_model = json.load(f)
 
 
@@ -471,10 +471,10 @@ def calc_energy(inputdata, DEBUG = False):
     ##----------------------------------------------------------------------------------
 
     # 窓データの読み込み
-    with open(database_directory + 'WindowHeatTransferPerformance.json', 'r') as f:
+    with open(database_directory + 'WindowHeatTransferPerformance.json', 'r', encoding='utf-8') as f:
         WindowHeatTransferPerformance = json.load(f)
 
-    with open(database_directory + 'glass2window.json', 'r') as f:
+    with open(database_directory + 'glass2window.json', 'r', encoding='utf-8') as f:
         glass2window = json.load(f)
 
 
@@ -956,7 +956,7 @@ def calc_energy(inputdata, DEBUG = False):
     ##----------------------------------------------------------------------------------
 
     ## 室負荷計算のための係数（解説書 A.3）
-    with open(database_directory + 'QROOM_COEFFI_AREA'+ inputdata["Building"]["Region"] +'.json', 'r') as f:
+    with open(database_directory + 'QROOM_COEFFI_AREA'+ inputdata["Building"]["Region"] +'.json', 'r', encoding='utf-8') as f:
         QROOM_COEFFI = json.load(f)
 
     
@@ -1152,7 +1152,7 @@ def calc_energy(inputdata, DEBUG = False):
     if SWITCH_BUILELIB_HEATLOADCALC:
 
         # 負荷計算モジュールの読み込み
-        from heat_load_calculation import Main
+        from .heat_load_calculation import Main
         import copy
 
         # ファイルの読み込み
@@ -1469,7 +1469,7 @@ def calc_energy(inputdata, DEBUG = False):
                             )
 
             # デバッグ用
-            # with open("heatloadcalc_input.json",'w') as fw:
+            # with open("heatloadcalc_input.json",'w', encoding='utf-8') as fw:
             #     json.dump(input_heatcalc, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)
             
             # 負荷計算の実行
@@ -3740,7 +3740,7 @@ def calc_energy(inputdata, DEBUG = False):
     ##----------------------------------------------------------------------------------
 
     # 地中熱オープンループの地盤特性の読み込み
-    with open(database_directory + 'AC_gshp_openloop.json', 'r') as f:
+    with open(database_directory + 'AC_gshp_openloop.json', 'r', encoding='utf-8') as f:
         AC_gshp_openloop = json.load(f)
 
     for ref_name in inputdata["REF"]:
@@ -4622,7 +4622,7 @@ def calc_energy(inputdata, DEBUG = False):
             + resultJson["for_CGS"]["E_pump_MWh_day"] \
             + resultJson["for_CGS"]["E_fan_MWh_day"]
 
-    # with open("inputdataJson_AC.json",'w') as fw:
+    # with open("inputdataJson_AC.json",'w', encoding='utf-8') as fw:
     #     json.dump(inputdata, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)
         
     return resultJson
@@ -4642,12 +4642,12 @@ if __name__ == '__main__':  # pragma: no cover
 
 
     # 入力ファイルの読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     resultJson = calc_energy(inputdata, DEBUG=True)
 
-    with open("resultJson_AC.json",'w') as fw:
+    with open("resultJson_AC.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)
 
     print( f'BEI/AC: {resultJson["BEI_AC"]}')        

--- a/builelib/climate.py
+++ b/builelib/climate.py
@@ -39,7 +39,7 @@ def readDatClimateData(filename):
     8760の行列
     """
 
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         reader = csv.reader(f)
         data = [row for row in reader]
 
@@ -65,7 +65,7 @@ def readHaspClimateData(filename):
     """
 
     # hasファイルの読み込み
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         hasData = f.readlines()
 
     Tout = list()   # 最終的に365×24の行列になる。

--- a/builelib/cogeneration.py
+++ b/builelib/cogeneration.py
@@ -5,7 +5,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
+from . import commons as bc
 
 # データベースファイルの保存場所
 database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
@@ -778,7 +778,7 @@ if __name__ == '__main__':  # pragma: no cover
     # filename = './sample/cgs.json'
 
     # テンプレートjsonの読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     # 各設備の計算
@@ -824,8 +824,8 @@ if __name__ == '__main__':  # pragma: no cover
 
     resultJson = calc_energy(inputdata, resultJson_for_CGS, DEBUG = True)
 
-    # with open("resultJson_for_CGS.json",'w') as fw:
+    # with open("resultJson_for_CGS.json",'w', encoding='utf-8') as fw:
     #     json.dump(resultJson_for_CGS, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)
 
-    with open("resultJson_CGS.json",'w') as fw:
+    with open("resultJson_CGS.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)

--- a/builelib/commons.py
+++ b/builelib/commons.py
@@ -18,15 +18,15 @@ database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
 template_directory =  os.path.dirname(os.path.abspath(__file__)) + "/inputdata/"
 
 # 基準値データベースの読み込み
-with open(database_directory + 'ROOM_STANDARDVALUE.json', 'r') as f:
+with open(database_directory + 'ROOM_STANDARDVALUE.json', 'r', encoding='utf-8') as f:
     RoomStandardValue = json.load(f)
 
 # 室使用条件データの読み込み
-with open(database_directory + 'RoomUsageSchedule.json', 'r') as f:
+with open(database_directory + 'RoomUsageSchedule.json', 'r', encoding='utf-8') as f:
     RoomUsageSchedule = json.load(f)
 
 # カレンダーパターンの読み込み
-with open(database_directory + 'CALENDAR.json', 'r') as f:
+with open(database_directory + 'CALENDAR.json', 'r', encoding='utf-8') as f:
     Calendar = json.load(f)
 
 class MyEncoder(json.JSONEncoder):
@@ -385,7 +385,7 @@ def get_dailyOpeSchedule_lighting(buildingType, roomType, input_calendar={}):
 def inputdata_validation(inputdata):
 
     # スキーマの読み込み
-    with open( template_directory + '/webproJsonSchema.json') as f:
+    with open( template_directory + '/webproJsonSchema.json', encoding='utf-8') as f:
         schema_data = json.load(f)    
 
     # 任意評定用（SP-1）

--- a/builelib/database_make/validation.py
+++ b/builelib/database_make/validation.py
@@ -5,11 +5,11 @@ targetFile = 'REFLIST.json'
 schemaFile = './builelib/database_make/schema/QROOM_COEFFI_schema.json'
 
 # スキーマの読み込み
-with open(schemaFile) as file_obj:
+with open(schemaFile, encoding='utf-8') as file_obj:
     schema_data = json.load(file_obj)
 
 # インプットデータの読み込み
-with open(targetFile) as file_obj:
+with open(targetFile, encoding='utf-8') as file_obj:
     check_data = json.load(file_obj)
 
 

--- a/builelib/elevetor.py
+++ b/builelib/elevetor.py
@@ -5,7 +5,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
+from . import commons as bc
 
 def calc_energy(inputdata, DEBUG = False):
 
@@ -172,11 +172,11 @@ if __name__ == '__main__':
     filename = './sample/Builelib_sample_SP7-1.json'
 
     # 入力ファイルの読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     resultJson = calc_energy(inputdata, DEBUG = True)
 
-    with open("resultJson_EV.json",'w') as fw:
+    with open("resultJson_EV.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)
 

--- a/builelib/hotwatersupply.py
+++ b/builelib/hotwatersupply.py
@@ -6,8 +6,8 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
-import climate
+from . import commons as bc
+from . import climate
 
 # データベースファイルの保存場所
 database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
@@ -31,7 +31,7 @@ def calc_energy(inputdata, DEBUG = False):
     }
     
     # 地域別データの読み込み
-    with open(database_directory + 'AREA.json', 'r') as f:
+    with open(database_directory + 'AREA.json', 'r', encoding='utf-8') as f:
         Area = json.load(f)
 
 
@@ -196,7 +196,7 @@ def calc_energy(inputdata, DEBUG = False):
     #----------------------------------------------------------------------------------
 
     # 給湯配管の線熱損失係数の読み込み
-    with open(database_directory + 'ThermalConductivityPiping.json', 'r') as f:
+    with open(database_directory + 'ThermalConductivityPiping.json', 'r', encoding='utf-8') as f:
         thermal_conductivity_dict = json.load(f)
 
     for unit_name in inputdata["HotwaterSupplySystems"]:
@@ -246,7 +246,7 @@ def calc_energy(inputdata, DEBUG = False):
                                     Area[inputdata["Building"]["Region"]+"地域"]["気象データファイル名（給湯）"])
 
     # 空調運転モード
-    with open(database_directory + 'ACoperationMode.json', 'r') as f:
+    with open(database_directory + 'ACoperationMode.json', 'r', encoding='utf-8') as f:
         ACoperationMode = json.load(f)
 
     # 各日の冷暖房期間の種類（冷房期、暖房期、中間期）（365×1の行列）
@@ -579,11 +579,11 @@ if __name__ == '__main__':
     filename = './sample/Builelib_sample_SP11.json'
 
     # 入力データ（json）の読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     resultJson = calc_energy(inputdata, DEBUG = True)
 
-    with open("resultJson_HW.json",'w') as fw:
+    with open("resultJson_HW.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)
 

--- a/builelib/lighting.py
+++ b/builelib/lighting.py
@@ -5,7 +5,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
+from . import commons as bc
 
 # データベースファイルの保存場所
 database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
@@ -40,7 +40,7 @@ def set_roomIndexCoeff(roomIndex):
 def calc_energy(inputdata, DEBUG = False):
 
     # データベースjsonの読み込み
-    with open( database_directory + 'lightingControl.json', 'r') as f:
+    with open( database_directory + 'lightingControl.json', 'r', encoding='utf-8') as f:
         lightingCtrl = json.load(f)
 
     # 計算結果を格納する変数
@@ -234,7 +234,7 @@ if __name__ == '__main__':
     # filename = './tests/cogeneration/Case_hotel_00.json'
 
     # テンプレートjsonの読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     resultJson = calc_energy(inputdata, DEBUG = False)
@@ -242,5 +242,5 @@ if __name__ == '__main__':
     print(f'設計値: {resultJson["E_lighting"]}')
     print(f'基準値: {resultJson["Es_lighting"]}')
 
-    with open("resultJson_L.json",'w') as fw:
+    with open("resultJson_L.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)

--- a/builelib/make_inputdata.py
+++ b/builelib/make_inputdata.py
@@ -6,7 +6,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
+from . import commons as bc
 
 # テンプレートファイルの保存場所
 template_directory =  os.path.dirname(os.path.abspath(__file__)) + "/inputdata/"
@@ -51,11 +51,11 @@ def make_jsondata_from_Ver4_sheet(inputfileName, validation = False):
     wb = xlrd.open_workbook(inputfileName)
 
     # テンプレートjsonの読み込み
-    with open( template_directory + 'template.json', 'r') as f:
+    with open( template_directory + 'template.json', 'r', encoding='utf-8') as f:
         data = json.load(f)
 
     # スキーマの読み込み
-    with open( template_directory + 'webproJsonSchema.json', 'r') as f:
+    with open( template_directory + 'webproJsonSchema.json', 'r', encoding='utf-8') as f:
         schema_data = json.load(f)
 
     # %%
@@ -1027,11 +1027,11 @@ def make_jsondata_from_Ver2_sheet(inputfileName, validation = False):
     wb = xlrd.open_workbook(inputfileName)
 
     # テンプレートjsonの読み込み
-    with open( template_directory + 'template.json', 'r') as f:
+    with open( template_directory + 'template.json', 'r', encoding='utf-8') as f:
         data = json.load(f)
 
     # スキーマの読み込み
-    with open( template_directory + 'webproJsonSchema.json', 'r') as f:
+    with open( template_directory + 'webproJsonSchema.json', 'r', encoding='utf-8') as f:
         schema_data = json.load(f)
     
 
@@ -1655,7 +1655,7 @@ def make_jsondata_from_Ver2_sheet(inputfileName, validation = False):
         # データベースファイルの保存場所
         database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
         ## 熱源機器特性
-        with open(database_directory + "HeatSourcePerformance.json", 'r') as f:
+        with open(database_directory + "HeatSourcePerformance.json", 'r', encoding='utf-8') as f:
             HeatSourcePerformance = json.load(f)
 
         # SP-2で作成した機種を追加
@@ -3128,7 +3128,7 @@ if __name__ == '__main__':
     # inputdata = make_jsondata_from_Ver4_sheet(directory + case_name + ".xlsx")
 
     # # json出力
-    # with open(directory + case_name + ".json",'w') as fw:
+    # with open(directory + case_name + ".json",'w', encoding='utf-8') as fw:
     #     json.dump(inputdata,fw,indent=4,ensure_ascii=False)
 
     #-----------------------
@@ -3141,7 +3141,7 @@ if __name__ == '__main__':
     inputdata = make_jsondata_from_Ver2_sheet(directory + case_name + ".xlsm", True)
 
     # json出力
-    with open(directory + case_name + ".json",'w') as fw:
+    with open(directory + case_name + ".json",'w', encoding='utf-8') as fw:
         json.dump(inputdata,fw,indent=4,ensure_ascii=False)
 
 
@@ -3155,7 +3155,7 @@ if __name__ == '__main__':
     # inputdata = make_jsondata_from_Ver2_sheet(directory + case_name + ".xlsm", True)
 
     # # json出力
-    # with open(directory + case_name + ".json",'w') as fw:
+    # with open(directory + case_name + ".json",'w', encoding='utf-8') as fw:
     #     json.dump(inputdata,fw,indent=4,ensure_ascii=False)
 
 
@@ -3173,7 +3173,7 @@ if __name__ == '__main__':
     #     inputdata = make_jsondata_from_Ver2_sheet(directory + case_name + ".xlsm", True)
 
     #     # json出力
-    #     with open(directory + case_name + ".json",'w') as fw:
+    #     with open(directory + case_name + ".json",'w', encoding='utf-8') as fw:
     #         json.dump(inputdata,fw,indent=4,ensure_ascii=False)
 
 
@@ -3191,5 +3191,5 @@ if __name__ == '__main__':
     #     inputdata = make_jsondata_from_Ver2_sheet(directory + case_name + ".xlsm", True)
 
     #     # json出力
-    #     with open(directory + case_name + ".json",'w') as fw:
+    #     with open(directory + case_name + ".json",'w', encoding='utf-8') as fw:
     #         json.dump(inputdata,fw,indent=4,ensure_ascii=False)

--- a/builelib/other_energy.py
+++ b/builelib/other_energy.py
@@ -7,9 +7,9 @@ import copy
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
-import climate
-import shading
+from . import commons as bc
+from . import climate
+from . import shading
 
 # データベースファイルの保存場所
 database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
@@ -206,10 +206,10 @@ if __name__ == '__main__':
     filename = './sample/Builelib_sample_SP9.json'
 
     # 入力ファイルの読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     resultJson = calc_energy(inputdata, DEBUG=True)
 
-    with open("resultJson_OT.json",'w') as fw:
+    with open("resultJson_OT.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)

--- a/builelib/photovoltaic.py
+++ b/builelib/photovoltaic.py
@@ -12,8 +12,8 @@ import math
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
-import climate
+from . import commons as bc
+from . import climate
 
 # 気象データファイルの保存場所
 climatedata_directory =  os.path.dirname(os.path.abspath(__file__)) + "/climatedata/"
@@ -256,12 +256,12 @@ if __name__ == '__main__':
     filename = './tests/photovoltaic/PV_case01.json'
 
     # テンプレートjsonの読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     resultJson = calc_energy(inputdata, DEBUG = True)
 
-    with open("resultJson_PV.json",'w') as fw:
+    with open("resultJson_PV.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)
 
     for system_name in resultJson["PhotovoltaicSystems"]:

--- a/builelib/shading.py
+++ b/builelib/shading.py
@@ -8,7 +8,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import climate
+from . import climate
 
 # データベースファイルの保存場所
 database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
@@ -312,7 +312,7 @@ def calc_shadingCoefficient(AREA, Direction, x1,x2,x3,y1,y2,y3,zxp,zxm,zyp,zym):
 
     ## 地域別データ読み込み
 
-    with open(database_directory + 'AREA.json', 'r') as f:
+    with open(database_directory + 'AREA.json', 'r', encoding='utf-8') as f:
         areaDB = json.load(f)
     climatefilename = climatedata_directory + '/C1_' + areaDB[AREA+"地域"]["気象データファイル名"] # 気象データ
 

--- a/builelib/subtools/makeFigure_HeatSourcePerformance.py
+++ b/builelib/subtools/makeFigure_HeatSourcePerformance.py
@@ -11,7 +11,7 @@ plt.rcParams['grid.linewidth'] = 0.5
 
 
 # データベースjsonの読み込み
-with open('./builelib/database/HeatSourcePerformance.json', 'r') as f:
+with open('./builelib/database/HeatSourcePerformance.json', 'r', encoding='utf-8') as f:
     db = json.load(f)
 
 

--- a/builelib/ventilation.py
+++ b/builelib/ventilation.py
@@ -5,7 +5,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import commons as bc
+from . import commons as bc
 
 # データベースファイルの保存場所
 database_directory =  os.path.dirname(os.path.abspath(__file__)) + "/database/"
@@ -165,7 +165,7 @@ def calc_energy(inputdata, DEBUG = False):
     ##----------------------------------------------------------------------------------
     ## 送風機の制御方式に応じて定められる係数（解説書 3.2）
     ##----------------------------------------------------------------------------------
-    with open( database_directory + '/ventilationControl.json', 'r') as f:
+    with open( database_directory + '/ventilationControl.json', 'r', encoding='utf-8') as f:
         ventilationCtrl = json.load(f)
 
     
@@ -373,7 +373,7 @@ if __name__ == '__main__':
     filename = './sample/Builelib_sample_SP9.json'
 
     # テンプレートjsonの読み込み
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         inputdata = json.load(f)
 
     resultJson = calc_energy(inputdata, DEBUG = False)
@@ -381,5 +381,5 @@ if __name__ == '__main__':
     print( f'設計一次エネルギー消費量[MJ] {resultJson["E_ventilation"]}')
     print( f'基準一次エネルギー消費量[MJ] {resultJson["Es_ventilation"]}')
 
-    with open("resultJson_V.json",'w') as fw:
+    with open("resultJson_V.json",'w', encoding='utf-8') as fw:
         json.dump(resultJson, fw, indent=4, ensure_ascii=False, cls = bc.MyEncoder)

--- a/builelib_run.py
+++ b/builelib_run.py
@@ -119,7 +119,7 @@ else:
     exec_calculation = False  # 計算は行わない。
 
 # 出力
-with open(inputfile_name_split[0] + "_input.json",'w') as fw:
+with open(inputfile_name_split[0] + "_input.json",'w', encoding='utf-8') as fw:
     json.dump(inputdata, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -160,7 +160,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_AC.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_AC.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_AC, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -201,7 +201,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_V.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_V.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_V, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -241,7 +241,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_L.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_L.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_L, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -281,7 +281,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_HW.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_HW.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_HW, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -321,7 +321,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_EV.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_EV.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_EV, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -359,7 +359,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_PV.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_PV.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_PV, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -394,7 +394,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_Other.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_Other.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_OT, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -428,7 +428,7 @@ else:
     }
 
 # 出力
-with open(inputfile_name_split[0] + "_result_CGS.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result_CGS.json",'w', encoding='utf-8') as fw:
     json.dump(resultdata_CGS, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 
@@ -455,7 +455,7 @@ else:
 # 計算結果ファイルの出力
 #------------------------------------
 
-with open(inputfile_name_split[0] + "_result.json",'w') as fw:
+with open(inputfile_name_split[0] + "_result.json",'w', encoding='utf-8') as fw:
     json.dump(calc_reuslt, fw, indent=4, ensure_ascii=False, cls = MyEncoder)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 numpy
-sys
-json
 jsonschema
-math
-csv
+pandas
+pytest
 xlrd == 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding='utf-8') as f:
     readme = f.read()
 
-with open('LICENSE') as f:
+with open('LICENSE', encoding='utf-8') as f:
     license = f.read()
 
 setup(

--- a/tests/test_airconditioning.py
+++ b/tests/test_airconditioning.py
@@ -53,7 +53,7 @@ for case_name in testcase_dict:
 
         filename = "./tests/airconditioning/ACtest_" + testdata[0] + ".json"
         # 入力データの作成
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             inputdata = json.load(f)
 
         # 期待値
@@ -70,7 +70,7 @@ for case_name in testcase_dict:
 def test_calc(inputdata, expectedvalue):
 
     # 検証用
-    with open("inputdata.json",'w') as fw:
+    with open("inputdata.json",'w', encoding='utf-8') as fw:
         json.dump(inputdata, fw, indent=4, ensure_ascii=False)
 
     # 計算実行        

--- a/tests/test_airconditioning_load.py
+++ b/tests/test_airconditioning_load.py
@@ -326,7 +326,7 @@ for case_name in testcase_dict:
 def test_calc(inputdata, expectedvalue):
 
     # 検証用
-    with open("inputdata.json",'w') as fw:
+    with open("inputdata.json",'w', encoding='utf-8') as fw:
         json.dump(inputdata, fw, indent=4, ensure_ascii=False)
 
     if expectedvalue[0] != "err":  # passが期待されるテスト

--- a/tests/test_airconditioning_openloop.py
+++ b/tests/test_airconditioning_openloop.py
@@ -55,7 +55,7 @@ for case_name in testcase_dict:
 
         filename = "./tests/airconditioning_gshp_openloop/AC_gshp_closeloop_base.json"
         # 入力データの読み込み
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             inputdata = json.load(f)
 
         # 地域
@@ -108,7 +108,7 @@ if __name__ == '__main__':
 
             filename = "./tests/airconditioning_gshp_openloop/AC_gshp_closeloop_base.json"
             # 入力データの読み込み
-            with open(filename, 'r') as f:
+            with open(filename, 'r', encoding='utf-8') as f:
                 inputdata = json.load(f)
 
             # 地域
@@ -134,7 +134,7 @@ if __name__ == '__main__':
                 str(resultJson["ENERGY"]["E_ctpump"] * bc.fprime)
             ]
 
-            with open("resultALL.txt",'a') as fw:
+            with open("resultALL.txt",'a', encoding='utf-8') as fw:
                 fw.write(testdata[0]+",")
                 fw.write(",".join(resultALL))
                 fw.write("\n")

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -87,7 +87,7 @@ def caclulation(inputdata):
     climate_directory = "./builelib/climatedata/"
 
     # 地域別データの読み込み
-    with open(database_directory + 'AREA.json', 'r') as f:
+    with open(database_directory + 'AREA.json', 'r', encoding='utf-8') as f:
         Area = json.load(f)
 
     # 直達日射量、天空日射量 [W/m2]

--- a/tests/test_cogeneration.py
+++ b/tests/test_cogeneration.py
@@ -61,7 +61,7 @@ for case_name in testcase_dict:
 
         filename = "./tests/cogeneration/" + testdata[0] + ".json"
         # 入力データの作成
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             inputdata = json.load(f)
 
         if "SpecialInputData" not in inputdata:
@@ -81,7 +81,7 @@ for case_name in testcase_dict:
 def test_calc(inputdata, expectedvalue):
 
     # 検証用
-    # with open("inputdata.json",'w') as fw:
+    # with open("inputdata.json",'w', encoding='utf-8') as fw:
     #     json.dump(inputdata, fw, indent=4, ensure_ascii=False)
 
 # 各設備の計算


### PR DESCRIPTION
Windows（Python 3.9）でも動くように以下の修正をしました。

1. ファイルを開くときにエンコーディングを指定。日本語版Windowsでは、UTF-8がデフォルトにはならないようです。
2. importを明示的な相対importに変更。