### PR TITLE
コジェネの排熱利用優先順位が空欄の場合は重複チェックの対象外とする

### DIFF
--- a/builelib/make_inputdata.py
+++ b/builelib/make_inputdata.py
@@ -3464,10 +3464,13 @@ def make_jsondata_from_Ver2_sheet(inputfileName):
         ## Varidation
         for csg_system in data["CogenerationSystems"]:
 
-            if check_duplicates([
-                data["CogenerationSystems"][csg_system]["HeatRecoveryPriorityCooling"],
-                data["CogenerationSystems"][csg_system]["HeatRecoveryPriorityHeating"], 
-                data["CogenerationSystems"][csg_system]["HeatRecoveryPriorityHotWater"]]):
+            # 重複をチェックする。ただし、空欄の重複は許可する。
+            if check_duplicates(list(filter(
+                lambda x : x != None and x != "", [
+                    data["CogenerationSystems"][csg_system]["HeatRecoveryPriorityCooling"],
+                    data["CogenerationSystems"][csg_system]["HeatRecoveryPriorityHeating"],
+                    data["CogenerationSystems"][csg_system]["HeatRecoveryPriorityHotWater"]
+                ]))):
 
                 validation["error"].append( "様式7-3.コジェネ: コージェネレーション設備名称「"+ csg_system +"」の排熱利用優先順位に重複があります。")
 


### PR DESCRIPTION
コジェネの排熱利用優先順位は、空調冷熱源、空調温熱源、給湯の3つ入力項目がありますが、
1つだけ入力して2つ空欄という使い方も出来たと思います。
その場合に、空欄2つが同じ優先順位を入力したとみなされ、入力チェックでエラーになります。
空欄は入力チェックの対象としないよう修正しました。