### PR TITLE
熱源の定格能力が0である場合のゼロ除算を回避する

### DIFF
--- a/builelib/airconditioning.py
+++ b/builelib/airconditioning.py
@@ -2434,11 +2434,11 @@ def calc_energy(inputdata, debug=False):
                 # 負荷率の算出 [-]
                 if resultJson["REF"][ref_name]["Qref_hourly"][dd][hh] > 0:
                     # 熱源定格負荷率（定格能力に対する比率）
-                    resultJson["REF"][ref_name]["load_ratio_rated"][dd][hh] = \
-                        (resultJson["REF"][ref_name]["Qref_hourly"][dd][hh] * 1000 / 3600) / inputdata["REF"][ref_name]["Qref_rated"]
-
-                if np.isnan(resultJson["REF"][ref_name]["load_ratio_rated"][dd][hh]):  # これは必要なのか？
-                    resultJson["REF"][ref_name]["load_ratio_rated"][dd][hh] = 0
+                    try:
+                        resultJson["REF"][ref_name]["load_ratio_rated"][dd][hh] = \
+                            (resultJson["REF"][ref_name]["Qref_hourly"][dd][hh] * 1000 / 3600) / inputdata["REF"][ref_name]["Qref_rated"]
+                    except ZeroDivisionError:
+                        resultJson["REF"][ref_name]["load_ratio_rated"][dd][hh] = 0
 
     #----------------------------------------------------------------------------------
     # 湿球温度 （解説書 2.7.4.2）
@@ -2893,7 +2893,10 @@ def calc_energy(inputdata, debug=False):
                     else:
 
                         for unit_id, unit_configure in enumerate(inputdata["REF"][ref_name]["Heatsource"]):
-                            resultJson["REF"][ref_name]["Heatsource"][unit_id]["load_ratio"][dd][hh] = tmpQ / Qrefr_mod_max
+                            try:
+                                resultJson["REF"][ref_name]["Heatsource"][unit_id]["load_ratio"][dd][hh] = tmpQ / Qrefr_mod_max
+                            except ZeroDivisionError:
+                                resultJson["REF"][ref_name]["Heatsource"][unit_id]["load_ratio"][dd][hh] = 0
 
     #----------------------------------------------------------------------------------
     # 部分負荷特性 （解説書 2.7.13）

--- a/builelib/cogeneration.py
+++ b/builelib/cogeneration.py
@@ -339,7 +339,8 @@ def calc_energy(inputdata, resultJson_for_CGS, DEBUG = False):
         qAC_ref_c_hr_d = np.zeros(365)
         EAC_ref_c_hr_d = np.zeros(365)
     else:
-        qAC_ref_c_hr_d = EAC_ref_c_d * ( np.sum(qAC_link_c_j_rated) / np.sum(EAC_link_c_j_rated)) * flink_d / fCOP_link_hr
+        # ゼロ除算が発生した場合、0とする。
+        qAC_ref_c_hr_d = np.nan_to_num(EAC_ref_c_d * ( np.sum(qAC_link_c_j_rated) / np.sum(EAC_link_c_j_rated)) * flink_d / fCOP_link_hr)
         EAC_ref_c_hr_d = EAC_ref_c_d * flink_d
 
 


### PR DESCRIPTION
熱源の定格能力が0である場合に発生するゼロ除算を回避するコードを追加しました。

`try` `except`でゼロ除算を回避しているのですが、このやり方の利点はゼロ除算の回避であることが分かりやすいこと、欠点はゼロ除算が発生した時点で警告が表示されることです。
`if`を使えば警告も発生しませんが、コードが若干冗長です。